### PR TITLE
fix: weekly Cilium upgrade never created PR due to GITHUB_OUTPUT bug

### DIFF
--- a/.github/workflows/weekly-cilium-upgrade.yaml
+++ b/.github/workflows/weekly-cilium-upgrade.yaml
@@ -25,106 +25,13 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Detect latest release and check for existing upgrade PR
-        id: precheck
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-          CILIUM_UPDATE_TOKEN: ${{ secrets.CILIUM_UPDATE_TOKEN }}
-          CILIUM_MIN_STABLE_PATCH: ${{ vars.CILIUM_MIN_STABLE_PATCH }}
+      - name: Read current Cilium version
+        id: current
         run: |
-          # Run the release checker with GITHUB_OUTPUT unset so it prints
-          # key=value lines to stdout, which we parse in this same step.
-          release_info=$(env -u GITHUB_OUTPUT cilium/tools/check-cilium-release.sh)
-          echo "${release_info}"
-
-          latest_version=$(sed -n 's/^latest_version=//p' <<< "${release_info}")
-          needs_update=$(sed -n 's/^needs_update=//p' <<< "${release_info}")
-          current_version=$(sed -n 's/^current_version=//p' <<< "${release_info}")
-
-          # Remove the generated context file so the worktree stays clean for
-          # the upgrade script (which regenerates it internally).
-          rm -f cilium/tools/cilium-upgrade-context.md
-
-          # Persist for use by downstream steps.
-          {
-            echo "current_version=${current_version}"
-            echo "latest_version=${latest_version}"
-            echo "needs_update=${needs_update}"
-          } >> "$GITHUB_OUTPUT"
-
-          if [[ "${needs_update}" != "true" ]]; then
-            echo "Cilium is already at the latest stable release (${latest_version})."
-            echo "skipped=true" >> "$GITHUB_OUTPUT"
-            echo "skip_reason=up_to_date" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          # List ALL open PRs from the automation branch and extract the
-          # version from each PR title. The title format is:
-          #   "chore: 将 Cilium 升级至 <version>"
-          # We use a regex to pull out the x.y.z version string.
-          search_token="${CILIUM_UPDATE_TOKEN:-${GITHUB_TOKEN}}"
-          pr_json=""
-          if [[ -n "${search_token}" ]]; then
-            pr_json=$(GH_TOKEN="${search_token}" gh pr list \
-              --state open \
-              --head automation/cilium-latest \
-              --json number,title \
-              2>/dev/null || true)
-          fi
-
-          # Find a PR whose title version matches the target version.
-          same_pr=""
-          # Find PRs whose title version is lower than the target version.
-          lower_prs=""
-          if [[ -n "${pr_json}" && "${pr_json}" != "[]" ]]; then
-            # Extract "number|title" pairs, then parse version from title.
-            while IFS='|' read -r pr_num pr_title; do
-              [[ -n "${pr_num}" ]] || continue
-              pr_version=$(printf '%s' "${pr_title}" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
-              if [[ -z "${pr_version}" ]]; then
-                continue
-              fi
-              if [[ "${pr_version}" == "${latest_version}" ]]; then
-                same_pr="${pr_num}"
-              else
-                # Is the PR's version lower than our target?
-                newest=$(printf '%s\n%s\n' "${pr_version}" "${latest_version}" | sort -V | tail -n 1)
-                if [[ "${newest}" == "${latest_version}" ]]; then
-                  lower_prs+="${pr_num} "
-                fi
-              fi
-            done < <(printf '%s' "${pr_json}" | jq -r '.[] | "\(.number)|\(.title)"')
-          fi
-
-          # Case 1: existing PR already targets the same version -> skip.
-          if [[ -n "${same_pr}" ]]; then
-            echo "Found existing open PR #${same_pr} already targeting Cilium ${latest_version}."
-            echo "Skipping this run to avoid duplicate work."
-            echo "skipped=true" >> "$GITHUB_OUTPUT"
-            echo "skip_reason=existing_pr" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          # Case 2: existing PR(s) target a lower version -> close them with
-          # a comment, then proceed to create a new PR for the higher version.
-          if [[ -n "${lower_prs}" ]]; then
-            echo "Found stale upgrade PR(s) targeting a lower version: ${lower_prs}"
-            for pr_num in ${lower_prs}; do
-              comment_body="自动关闭：检测到更高版本的 Cilium \`v${latest_version}\` 已发布。本次运行将创建针对 \`v${latest_version}\` 的新升级 PR 来替代此 PR。"
-              GH_TOKEN="${search_token}" gh pr close "${pr_num}" \
-                --comment "${comment_body}" \
-                --delete-branch \
-                2>/dev/null || true
-              echo "Closed stale PR #${pr_num}."
-            done
-          fi
-
-          echo "No existing PR targets Cilium ${latest_version}; proceeding with upgrade."
-          echo "skipped=false" >> "$GITHUB_OUTPUT"
+          source cilium/version.sh
+          echo "version=${CILIUM_VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Install AI CLIs and validation tools
-        if: steps.precheck.outputs.skipped != 'true'
         run: |
           npm install --global \
             @github/copilot@latest \
@@ -132,10 +39,10 @@ jobs:
             @openai/codex@latest
           make install-tools
 
-      - name: Run local-compatible upgrade script
-        if: steps.precheck.outputs.skipped != 'true'
+      - name: Run upgrade script
         id: upgrade
         env:
+          CURRENT_CILIUM_VERSION: ${{ steps.current.outputs.version }}
           AI_MODEL: ${{ vars.AI_MODEL }}
           GEMINI_MODEL: ${{ vars.GEMINI_MODEL }}
           COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
@@ -148,7 +55,7 @@ jobs:
           cilium/tools/run-cilium-upgrade.sh
 
       - name: Verify PR token
-        if: steps.precheck.outputs.skipped != 'true' && steps.upgrade.outputs.changed == 'true'
+        if: steps.upgrade.outputs.changed == 'true'
         env:
           CILIUM_UPDATE_TOKEN: ${{ secrets.CILIUM_UPDATE_TOKEN }}
         run: |
@@ -158,7 +65,7 @@ jobs:
           }
 
       - name: Create or update upgrade PR
-        if: steps.precheck.outputs.skipped != 'true' && steps.upgrade.outputs.changed == 'true'
+        if: steps.upgrade.outputs.changed == 'true'
         id: cpr
         uses: peter-evans/create-pull-request@v8
         with:
@@ -166,8 +73,8 @@ jobs:
           branch: automation/cilium-latest
           delete-branch: true
           commit-message: |
-            chore: 将 Cilium 升级至 ${{ steps.precheck.outputs.latest_version }}
-          title: 'chore: 将 Cilium 升级至 ${{ steps.precheck.outputs.latest_version }}'
+            chore: 将 Cilium 升级至 ${{ steps.upgrade.outputs.latest_version }}
+          title: 'chore: 将 Cilium 升级至 ${{ steps.upgrade.outputs.latest_version }}'
           body-path: ${{ steps.upgrade.outputs.pr_body_path }}
           add-paths: |
             cilium/**

--- a/cilium/tools/check-cilium-release.sh
+++ b/cilium/tools/check-cilium-release.sh
@@ -3,16 +3,16 @@
 set -euo pipefail
 
 project_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
-version_file="${project_root}/cilium/version.sh"
 context_file="${project_root}/cilium/tools/cilium-upgrade-context.md"
 api_url="https://api.github.com/repos/cilium/cilium/releases?per_page=100"
 
-current_version=$(
-    sed -n 's/^[[:space:]]*CILIUM_VERSION=${CILIUM_VERSION:-"\([^"]*\)"}.*/\1/p' "${version_file}"
-)
+# The current Cilium version is provided by the caller (the workflow sources
+# cilium/version.sh and exports CURRENT_CILIUM_VERSION). This keeps the
+# script a pure function of its inputs and avoids re-reading version.sh.
+current_version="${CURRENT_CILIUM_VERSION:-}"
 
 if [[ ! "${current_version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-    echo "Unable to read a stable Cilium version from ${version_file}" >&2
+    echo "CURRENT_CILIUM_VERSION must be set to a stable x.y.z version" >&2
     exit 1
 fi
 
@@ -186,15 +186,8 @@ fi
     done
 } > "${context_file}"
 
-if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
-    {
-        echo "current_version=${current_version}"
-        echo "latest_version=${latest_version}"
-        echo "latest_tag=${latest_tag}"
-        echo "release_url=${release_url}"
-        echo "needs_update=${needs_update}"
-    } >> "${GITHUB_OUTPUT}"
-else
-    printf 'current_version=%s\nlatest_version=%s\nrelease_url=%s\nneeds_update=%s\n' \
-        "${current_version}" "${latest_version}" "${release_url}" "${needs_update}"
-fi
+# Always print results to stdout so the caller (run-cilium-upgrade.sh or a
+# workflow step) can parse them with sed/jq. Never write to GITHUB_OUTPUT
+# here — the caller owns that decision.
+printf 'current_version=%s\nlatest_version=%s\nlatest_tag=%s\nrelease_url=%s\nneeds_update=%s\n' \
+    "${current_version}" "${latest_version}" "${latest_tag}" "${release_url}" "${needs_update}"

--- a/cilium/tools/run-cilium-upgrade.sh
+++ b/cilium/tools/run-cilium-upgrade.sh
@@ -10,6 +10,16 @@ version_file="${project_root}/cilium/version.sh"
 pr_body_file=${CILIUM_UPGRADE_PR_BODY:-"/tmp/cilium-upgrade-pr.md"}
 check_only=false
 
+# Current Cilium version: prefer the value supplied by the workflow (which
+# sources cilium/version.sh). Fall back to reading version.sh directly so
+# the script remains usable for local manual runs.
+if [[ -z "${CURRENT_CILIUM_VERSION:-}" ]]; then
+    CURRENT_CILIUM_VERSION=$(
+        sed -n 's/^[[:space:]]*CILIUM_VERSION=${CILIUM_VERSION:-"\([^"]*\)"}.*/\1/p' "${version_file}"
+    )
+fi
+export CURRENT_CILIUM_VERSION
+
 usage() {
     cat <<'EOF'
 Usage: cilium/tools/run-cilium-upgrade.sh [--check-only]
@@ -20,6 +30,9 @@ The script tries each AI CLI in priority order until one succeeds:
   3. codex    (requires CODEX_API_KEY or OPENAI_API_KEY)
 
 Environment:
+  CURRENT_CILIUM_VERSION   Current pinned Cilium version (x.y.z). When set,
+                           it is forwarded to check-cilium-release.sh. When
+                           unset, the script reads cilium/version.sh itself.
   COPILOT_GITHUB_TOKEN      Copilot credential (fine-grained PAT with
                             "Copilot Requests" permission).
   GEMINI_API_KEY            Gemini API key from Google AI Studio.


### PR DESCRIPTION
## Summary

- `check-cilium-release.sh` 在 CI 下因 `GITHUB_OUTPUT` 已设置而走"写文件"分支，stdout 为空，导致 `run-cilium-upgrade.sh` 解析出空变量，误判"已是最新版本"提前退出，从不创建升级 PR（[run #28315518894](https://github.com/spidernet-io/deployCilium/actions/runs/28315518894/job/83887910462) 即此问题）
- 删除 `check-cilium-release.sh` 的 `GITHUB_OUTPUT` 双模式分支，永远打印 stdout；改为接收 `CURRENT_CILIUM_VERSION` 环境变量，不再自己读 `version.sh`
- `run-cilium-upgrade.sh` 优先使用 workflow 传入的 `CURRENT_CILIUM_VERSION`，未设时 fallback 读 `version.sh`（保留本地手动跑能力）
- `weekly-cilium-upgrade.yaml` 用 `source cilium/version.sh` 拿当前版本传入；删除 60 行 precheck step，PR 去重由 `peter-evans/create-pull-request` 的固定 branch 自动处理

#### Test plan

- [x] `CURRENT_CILIUM_VERSION=1.18.3 cilium/tools/check-cilium-release.sh` → 正确输出 `latest_version=1.18.11`、`needs_update=true`
- [x] 未设 `CURRENT_CILIUM_VERSION` → 报错退出（exit 1）
- [x] `run-cilium-upgrade.sh --check-only`（fallback 读 version.sh）→ 正确识别 1.18.3 → 1.18.11
- [x] 传入 `CURRENT_CILIUM_VERSION=1.19.5`（已是最新）→ 正确输出 `needs_update=false` 并退出
- [x] 模拟 CI 环境（设 `GITHUB_OUTPUT`）调用 `run-cilium-upgrade.sh --check-only` → stdout 解析正常，不再出现空变量 bug
- [ ] 触发一次 `workflow_dispatch` 验证端到端创建升级 PR

Generated with [Devin](https://devin.ai)