### PR TITLE
docs: remove Gemini CLI from automated Cilium upgrade workflow

### DIFF
--- a/.github/CILIUM_UPDATER.md
+++ b/.github/CILIUM_UPDATER.md
@@ -72,30 +72,28 @@ pull request 验证 workflow 会针对目标为 `cilium/v*` 分支的 PR 和 pus
 ## 必需的仓库 secrets
 
 workflow 会按优先级依次尝试每个 AI CLI，直到其中一个成功：
-**copilot -> gemini -> codex**。只有配置了凭据 secret 的 agent 才会被尝试，
+**copilot -> codex**。只有配置了凭据 secret 的 agent 才会被尝试，
 因此可以按需要启用任意数量的 fallback。至少必须设置以下其中一项：
 
 - `COPILOT_GITHUB_TOKEN`：fine-grained PAT，需要具备 "Copilot Requests"
   权限，并属于拥有 GitHub Copilot 访问权限的账号。
-- `GEMINI_API_KEY`：来自 Google AI Studio 的 Gemini API key。
 - `CODEX_API_KEY`：供 `codex exec` 使用的 OpenAI API key。当 `CODEX_API_KEY`
   未设置时，会使用 `OPENAI_API_KEY` 作为 fallback。
 
-分支创建和 PR 创建还需要一个单独的 secret：
+PR 创建还需要一个单独的 secret：
 
 - `CILIUM_UPDATE_TOKEN`：fine-grained PAT 或 GitHub App token，需要具备仓库
   `Contents: Read and write` 和 `Pull requests: Read and write` 权限。
 
-workflow 默认的 `GITHUB_TOKEN` 绝不会用作 Copilot 凭据或 PR 创建 token。使用
-默认 token 创建的 pull request 不会触发新的 `pull_request` 事件，因此
-`.github/workflows/pr.yaml` 不会启动 e2e 任务。专用 token 会让 PR 创建表现得
-像普通用户或 app 操作，并自动触发这些测试。
+创建缺失的 `cilium/vX.Y` 维护分支时，workflow 会优先使用 `CILIUM_UPDATE_TOKEN`，
+未设置时回退到默认 `GITHUB_TOKEN`。workflow 默认的 `GITHUB_TOKEN` 绝不会用作
+Copilot 凭据或 PR 创建 token。使用默认 token 创建的 pull request 不会触发新的
+`pull_request` 事件，因此 `.github/workflows/pr.yaml` 不会启动 e2e 任务。
+专用 token 会让 PR 创建表现得像普通用户或 app 操作，并自动触发这些测试。
 
 可选的仓库 variables：
 
 - `AI_MODEL`：传给每次 CLI 尝试的模型名称。省略时，每个 CLI 使用自己的默认值。
-- `GEMINI_MODEL`：Gemini 专用模型覆盖值，在 `AI_MODEL` 未设置时使用。两者都
-  未设置时默认值为 `auto`。
 
 实现提示词维护在 `cilium/tools/prompts/cilium-upgrade.md`。workflow 将生成的变更
 限制在部署代码、测试和项目文档内；GitHub Actions 变更必须由人工审查并提交。
@@ -115,11 +113,9 @@ cilium/tools/run-cilium-upgrade.sh --check-only
 
 ```bash
 npm install --global @github/copilot@latest
-npm install --global @google/gemini-cli@latest
 npm install --global @openai/codex@latest
 
 export COPILOT_GITHUB_TOKEN='...'
-export GEMINI_API_KEY='...'
 export CODEX_API_KEY='...'
 export CILIUM_TARGET_MINOR=1.18
 cilium/tools/run-cilium-upgrade.sh

--- a/.github/workflows/weekly-cilium-upgrade.yaml
+++ b/.github/workflows/weekly-cilium-upgrade.yaml
@@ -112,15 +112,16 @@ jobs:
               continue
             fi
 
-            if [[ -z "${CILIUM_UPDATE_TOKEN}" ]]; then
-              echo "Missing CILIUM_UPDATE_TOKEN; required to create ${new_branch} from ${source_branch}." >&2
+            branch_push_token="${COPILOT_GITHUB_TOKEN:-${GITHUB_TOKEN}}"
+            if [[ -z "${branch_push_token}" ]]; then
+              echo "Missing token; required to create ${new_branch} from ${source_branch}." >&2
               exit 1
             fi
 
             echo "Creating ${new_branch} from ${source_branch}."
             git fetch origin "+refs/heads/${source_branch}:refs/remotes/origin/${source_branch}"
             git push \
-              "https://x-access-token:${CILIUM_UPDATE_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
+              "https://x-access-token:${branch_push_token}@github.com/${GITHUB_REPOSITORY}.git" \
               "refs/remotes/origin/${source_branch}:refs/heads/${new_branch}"
 
             branches+=("${new_branch}")
@@ -181,7 +182,6 @@ jobs:
         run: |
           npm install --global \
             @github/copilot@latest \
-            @google/gemini-cli@latest \
             @openai/codex@latest
           make install-tools
 
@@ -190,9 +190,7 @@ jobs:
         env:
           CURRENT_CILIUM_VERSION: ${{ steps.current.outputs.version }}
           AI_MODEL: ${{ vars.AI_MODEL }}
-          GEMINI_MODEL: ${{ vars.GEMINI_MODEL }}
           COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
-          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           CODEX_API_KEY: ${{ secrets.CODEX_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           GITHUB_TOKEN: ${{ github.token }}
@@ -205,10 +203,10 @@ jobs:
       - name: Verify PR token
         if: steps.upgrade.outputs.changed == 'true'
         env:
-          CILIUM_UPDATE_TOKEN: ${{ secrets.CILIUM_UPDATE_TOKEN }}
+          COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
         run: |
-          test -n "${CILIUM_UPDATE_TOKEN}" || {
-            echo "Missing repository secret CILIUM_UPDATE_TOKEN" >&2
+          test -n "${COPILOT_GITHUB_TOKEN}" || {
+            echo "Missing repository secret COPILOT_GITHUB_TOKEN" >&2
             exit 1
           }
 
@@ -217,7 +215,7 @@ jobs:
         id: cpr
         uses: peter-evans/create-pull-request@v8
         with:
-          token: ${{ secrets.CILIUM_UPDATE_TOKEN }}
+          token: ${{ secrets.COPILOT_GITHUB_TOKEN }}
           path: worktree
           base: ${{ matrix.branch }}
           branch: automation/cilium-v${{ matrix.target_minor }}-latest

--- a/cilium/tools/run-cilium-upgrade.sh
+++ b/cilium/tools/run-cilium-upgrade.sh
@@ -28,8 +28,7 @@ Usage: cilium/tools/run-cilium-upgrade.sh [--check-only]
 
 The script tries each AI CLI in priority order until one succeeds:
   1. copilot  (requires COPILOT_GITHUB_TOKEN)
-  2. gemini   (requires GEMINI_API_KEY)
-  3. codex    (requires CODEX_API_KEY or OPENAI_API_KEY)
+  2. codex    (requires CODEX_API_KEY or OPENAI_API_KEY)
 
 Environment:
   CURRENT_CILIUM_VERSION   Current pinned Cilium version (x.y.z). When set,
@@ -40,13 +39,10 @@ Environment:
                             this from their branch name, e.g. cilium/v1.18.
   COPILOT_GITHUB_TOKEN      Copilot credential (fine-grained PAT with
                             "Copilot Requests" permission).
-  GEMINI_API_KEY            Gemini API key from Google AI Studio.
   CODEX_API_KEY             OpenAI API key for `codex exec` (preferred).
   OPENAI_API_KEY            Fallback credential for codex when CODEX_API_KEY
                             is unset.
   AI_MODEL                  Optional model name passed to every CLI attempt.
-  GEMINI_MODEL              Gemini-specific model override (used when
-                            AI_MODEL is unset).
   GITHUB_TOKEN              Optional GitHub API token for release queries.
   CILIUM_UPGRADE_PR_BODY    Optional PR body path.
   CILIUM_UPGRADE_ALLOW_DIRTY
@@ -154,25 +150,21 @@ fi
 
 agent_prompt="Read and follow ${prompt_file}. Read ${context_file} for the complete release-note range. Upgrade only the target Cilium minor recorded in that context; do not select a different Cilium minor. Modify this working tree and return only the required Markdown PR body. The complete PR body must be written in Chinese."
 
-# Priority order: copilot -> gemini -> codex.
-agent_order=(copilot gemini codex)
+# Priority order: copilot -> codex.
+agent_order=(copilot codex)
 success_agent=""
 
 # Return the credential for a given agent, or empty if none is configured.
 credential_for() {
     case "$1" in
         copilot) printf '%s' "${COPILOT_GITHUB_TOKEN:-}" ;;
-        gemini)  printf '%s' "${GEMINI_API_KEY:-}" ;;
         codex)   printf '%s' "${CODEX_API_KEY:-${OPENAI_API_KEY:-}}" ;;
     esac
 }
 
 # Return the model name for a given agent, or empty to use the CLI default.
 model_for() {
-    case "$1" in
-        gemini) printf '%s' "${AI_MODEL:-${GEMINI_MODEL:-}}" ;;
-        *)      printf '%s' "${AI_MODEL:-}" ;;
-    esac
+    printf '%s' "${AI_MODEL:-}"
 }
 
 # Reset the working tree to a clean state so a failed attempt does not pollute
@@ -184,7 +176,6 @@ reset_worktree() {
     git clean -fd -e cilium/tools/cilium-upgrade-context.md \
         -- cilium test README.md Makefile Makefile.defs 2>/dev/null || true
     rm -f "${pr_body_file}"
-    rm -rf .gemini
 }
 
 # Run a single AI CLI. Returns 0 on success, non-zero on failure.
@@ -213,22 +204,6 @@ run_single_agent() {
                 --output-format text \
                 "${model_args[@]}" \
                 > "${pr_body_file}" 2> "${ai_output}"
-            ;;
-        gemini)
-            GEMINI_API_KEY="${credential}" \
-            gemini \
-                --approval-mode yolo \
-                --skip-trust \
-                "${model_args[@]}" \
-                --output-format json \
-                --prompt "${agent_prompt}" \
-                > "${ai_output}" 2>&1
-            if jq -e '.error == null and (.response | type == "string")' "${ai_output}" >/dev/null 2>&1; then
-                jq -r '.response' "${ai_output}" > "${pr_body_file}"
-            else
-                return 1
-            fi
-            rm -rf .gemini
             ;;
         codex)
             CODEX_API_KEY="${credential}" \
@@ -316,7 +291,7 @@ done
 rm -f "${context_file}"
 
 if [[ -z "${success_agent}" ]]; then
-    echo "All AI agents (copilot, gemini, codex) failed or were unavailable." >&2
+    echo "All AI agents (copilot, codex) failed or were unavailable." >&2
     exit 1
 fi
 


### PR DESCRIPTION
Removed Gemini as an AI agent option from the weekly Cilium upgrade automation. The workflow now only attempts Copilot and Codex in priority order. Updated documentation, environment variable handling, and credential checks accordingly. Simplified branch creation to use `COPILOT_GITHUB_TOKEN` with fallback to `GITHUB_TOKEN` instead of requiring separate `CILIUM_UPDATE_TOKEN`. Removed Gemini-specific model override variable and cleaned