### PR TITLE
docs: introduce AUTOMATION_GITHUB_TOKEN and deprecate COPILOT_GITHUB_…

### DIFF
--- a/.github/CILIUM_UPDATER.md
+++ b/.github/CILIUM_UPDATER.md
@@ -98,17 +98,23 @@ workflow 会按优先级依次尝试每个 AI CLI，直到其中一个成功：
 **copilot -> deepseek**。只有配置了凭据 secret 的 agent 才会被尝试，
 因此可以按需要启用任意数量的 fallback。至少必须设置以下其中一项：
 
-- `COPILOT_GITHUB_TOKEN`：fine-grained PAT，需要具备 "Copilot Requests"、
-  `Contents: Read and write` 和 `Pull requests: Read and write` 权限，并属于拥有
-  GitHub Copilot 访问权限的账号。workflow 也使用该 token 创建维护分支和 PR。
+- `COPILOT_GITHUB_TOKEN`：供 GitHub Copilot CLI 使用的凭据，需要具备
+  "Copilot Requests" 权限，并属于拥有 GitHub Copilot 访问权限的账号。
 - `DEEPSEEK_API_KEY`：供 `opencode run` 调用 DeepSeek 使用的 API key。
 
-创建缺失的 `cilium/vX.Y` 维护分支时，workflow 会优先使用 `COPILOT_GITHUB_TOKEN`，
-未设置时回退到默认 `GITHUB_TOKEN`。创建或更新 PR 时必须设置 `COPILOT_GITHUB_TOKEN`。
-workflow 默认的 `GITHUB_TOKEN` 绝不会用作 Copilot 凭据或 PR 创建 token。使用默认
-token 创建的 pull request 不会触发新的 `pull_request` 事件，因此
-`.github/workflows/pr.yaml` 不会启动 e2e 任务。`COPILOT_GITHUB_TOKEN` 会让 PR 创建
-表现得像普通用户操作，并自动触发这些测试。
+创建维护分支、推送自动化分支、创建或更新 PR 需要额外配置：
+
+- `AUTOMATION_GITHUB_TOKEN`：fine-grained PAT，需要授权给
+  `spidernet-io/deployCilium`，并授予 `Contents: Read and write` 和
+  `Pull requests: Read and write` 权限。建议使用独立的自动化账号 token。
+
+创建缺失的 `cilium/vX.Y` 维护分支时，workflow 会优先使用
+`AUTOMATION_GITHUB_TOKEN`，未设置时依次回退到 `COPILOT_GITHUB_TOKEN` 和默认
+`GITHUB_TOKEN`。创建或更新 PR 时优先使用 `AUTOMATION_GITHUB_TOKEN`；为了兼容旧配置，
+未设置时会回退到 `COPILOT_GITHUB_TOKEN`。workflow 默认的 `GITHUB_TOKEN` 绝不会用作
+Copilot 凭据或 PR 创建 token。使用默认 token 创建的 pull request 不会触发新的
+`pull_request` 事件，因此 `.github/workflows/pr.yaml` 不会启动 e2e 任务。
+`AUTOMATION_GITHUB_TOKEN` 会让 PR 创建表现得像普通用户操作，并自动触发这些测试。
 
 可选的仓库 variables：
 

--- a/.github/workflows/monthly-cilium-upgrade.yaml
+++ b/.github/workflows/monthly-cilium-upgrade.yaml
@@ -33,6 +33,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
           COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+          AUTOMATION_GITHUB_TOKEN: ${{ secrets.AUTOMATION_GITHUB_TOKEN }}
         run: |
           set -euo pipefail
 
@@ -120,7 +121,7 @@ jobs:
             if branch_exists "${new_branch}"; then
               source_branch="${new_branch}"
             else
-              branch_push_token="${COPILOT_GITHUB_TOKEN:-${GITHUB_TOKEN}}"
+              branch_push_token="${AUTOMATION_GITHUB_TOKEN:-${COPILOT_GITHUB_TOKEN:-${GITHUB_TOKEN}}}"
               if [[ -z "${branch_push_token}" ]]; then
                 echo "Missing token; required to create ${new_branch} from ${source_branch}." >&2
                 exit 1
@@ -255,24 +256,24 @@ jobs:
       - name: Verify PR token
         if: steps.upgrade.outputs.changed == 'true'
         env:
-          COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+          PR_GITHUB_TOKEN: ${{ secrets.AUTOMATION_GITHUB_TOKEN || secrets.COPILOT_GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
         run: |
           set -euo pipefail
 
-          test -n "${COPILOT_GITHUB_TOKEN}" || {
-            echo "Missing repository secret COPILOT_GITHUB_TOKEN" >&2
+          test -n "${PR_GITHUB_TOKEN}" || {
+            echo "Missing repository secret AUTOMATION_GITHUB_TOKEN; falling back to COPILOT_GITHUB_TOKEN also found nothing." >&2
             exit 1
           }
 
           curl --fail --silent --show-error --location \
             -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer ${COPILOT_GITHUB_TOKEN}" \
+            -H "Authorization: Bearer ${PR_GITHUB_TOKEN}" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             "https://api.github.com/repos/${GITHUB_REPOSITORY}" \
             >/dev/null || {
-              echo "COPILOT_GITHUB_TOKEN is not valid for ${GITHUB_REPOSITORY}." >&2
-              echo "Check that the repository secret is current and grants Contents: Read and write plus Pull requests: Read and write." >&2
+              echo "PR GitHub token is not valid for ${GITHUB_REPOSITORY}." >&2
+              echo "Set AUTOMATION_GITHUB_TOKEN to a fine-grained PAT that grants Contents: Read and write plus Pull requests: Read and write." >&2
               exit 1
             }
 
@@ -280,19 +281,19 @@ jobs:
         if: steps.upgrade.outputs.changed == 'true'
         working-directory: worktree
         env:
-          COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+          PR_GITHUB_TOKEN: ${{ secrets.AUTOMATION_GITHUB_TOKEN || secrets.COPILOT_GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
         run: |
           set -euo pipefail
 
-          git remote set-url origin "https://x-access-token:${COPILOT_GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          git remote set-url origin "https://x-access-token:${PR_GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
 
       - name: Create or update upgrade PR
         if: steps.upgrade.outputs.changed == 'true'
         id: cpr
         uses: peter-evans/create-pull-request@v8
         with:
-          token: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+          token: ${{ secrets.AUTOMATION_GITHUB_TOKEN || secrets.COPILOT_GITHUB_TOKEN }}
           path: worktree
           base: ${{ matrix.branch }}
           branch: automation/cilium-v${{ matrix.target_minor }}-latest
@@ -325,7 +326,7 @@ jobs:
       - name: Check out main
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+          token: ${{ secrets.AUTOMATION_GITHUB_TOKEN || secrets.COPILOT_GITHUB_TOKEN }}
           fetch-depth: 0
 
       - name: Update supported Cilium versions file
@@ -359,41 +360,41 @@ jobs:
 
       - name: Verify PR token
         env:
-          COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+          PR_GITHUB_TOKEN: ${{ secrets.AUTOMATION_GITHUB_TOKEN || secrets.COPILOT_GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
         run: |
           set -euo pipefail
 
-          test -n "${COPILOT_GITHUB_TOKEN}" || {
-            echo "Missing repository secret COPILOT_GITHUB_TOKEN" >&2
+          test -n "${PR_GITHUB_TOKEN}" || {
+            echo "Missing repository secret AUTOMATION_GITHUB_TOKEN; falling back to COPILOT_GITHUB_TOKEN also found nothing." >&2
             exit 1
           }
 
           curl --fail --silent --show-error --location \
             -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer ${COPILOT_GITHUB_TOKEN}" \
+            -H "Authorization: Bearer ${PR_GITHUB_TOKEN}" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             "https://api.github.com/repos/${GITHUB_REPOSITORY}" \
             >/dev/null || {
-              echo "COPILOT_GITHUB_TOKEN is not valid for ${GITHUB_REPOSITORY}." >&2
-              echo "Check that the repository secret is current and grants Contents: Read and write plus Pull requests: Read and write." >&2
+              echo "PR GitHub token is not valid for ${GITHUB_REPOSITORY}." >&2
+              echo "Set AUTOMATION_GITHUB_TOKEN to a fine-grained PAT that grants Contents: Read and write plus Pull requests: Read and write." >&2
               exit 1
             }
 
       - name: Configure manifest PR branch push credentials
         env:
-          COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+          PR_GITHUB_TOKEN: ${{ secrets.AUTOMATION_GITHUB_TOKEN || secrets.COPILOT_GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
         run: |
           set -euo pipefail
 
-          git remote set-url origin "https://x-access-token:${COPILOT_GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          git remote set-url origin "https://x-access-token:${PR_GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
 
       - name: Create or update manifest PR
         id: manifest-pr
         uses: peter-evans/create-pull-request@v8
         with:
-          token: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+          token: ${{ secrets.AUTOMATION_GITHUB_TOKEN || secrets.COPILOT_GITHUB_TOKEN }}
           base: main
           branch: automation/cilium-supported-versions
           delete-branch: true


### PR DESCRIPTION
…TOKEN for PR operations

Replaced COPILOT_GITHUB_TOKEN with AUTOMATION_GITHUB_TOKEN as the primary token for creating maintenance branches, pushing automation branches, and creating/updating PRs. COPILOT_GITHUB_TOKEN now only provides Copilot CLI credentials and serves as fallback for PR operations when AUTOMATION_GITHUB_TOKEN is unset.

Updated CILIUM_UPDATER.md to clarify token responsibilities: COPILOT_GITHUB_TOKEN requires only