### PR TITLE
[codex] sync PR_TOKEN automation updates to main

### DIFF
--- a/.github/CILIUM_UPDATER.md
+++ b/.github/CILIUM_UPDATER.md
@@ -125,16 +125,18 @@ workflow 会按优先级依次尝试每个 AI CLI，直到其中一个成功：
 **copilot -> deepseek**。只有配置了凭据 secret 的 agent 才会被尝试，
 因此可以按需要启用任意数量的 fallback。至少必须设置以下其中一项：
 
-- `COPILOT_GITHUB_TOKEN`：fine-grained PAT，需要具备 "Copilot Requests"、
-  `Contents: Read and write` 和 `Pull requests: Read and write` 权限，并属于拥有
-  GitHub Copilot 访问权限的账号。workflow 也使用该 token 创建维护分支和 PR。
+- `COPILOT_GITHUB_TOKEN`：Copilot CLI 凭据，需要可用于 `@github/copilot` CLI。
+  它只用于 AI 升级步骤，不用于创建分支或 PR。
+- `PR_TOKEN`：fine-grained PAT，需要具备 `Contents: Read and write` 和
+  `Pull requests: Read and write` 权限。workflow 使用该 token 创建维护分支、推送
+  自动化分支并创建或更新 PR。
 - `DEEPSEEK_API_KEY`：供 `opencode run` 调用 DeepSeek 使用的 API key。
 
-创建缺失的 `cilium/release-vX.Y` 维护分支时，workflow 会优先使用 `COPILOT_GITHUB_TOKEN`，
-未设置时回退到默认 `GITHUB_TOKEN`。创建或更新 PR 时必须设置 `COPILOT_GITHUB_TOKEN`。
+创建缺失的 `cilium/release-vX.Y` 维护分支时，workflow 会优先使用 `PR_TOKEN`，
+未设置时回退到默认 `GITHUB_TOKEN`。创建或更新 PR 时必须设置 `PR_TOKEN`。
 workflow 默认的 `GITHUB_TOKEN` 绝不会用作 Copilot 凭据或 PR 创建 token。使用默认
 token 创建的 pull request 不会触发新的 `pull_request` 事件，因此
-`.github/workflows/pr.yaml` 不会启动 e2e 任务。`COPILOT_GITHUB_TOKEN` 会让 PR 创建
+`.github/workflows/pr.yaml` 不会启动 e2e 任务。`PR_TOKEN` 会让 PR 创建
 表现得像普通用户操作，并自动触发这些测试。
 
 可选的仓库 variables：
@@ -166,6 +168,7 @@ npm install --global @github/copilot@latest
 npm install --global opencode-ai@latest
 
 export COPILOT_GITHUB_TOKEN='...'
+export PR_TOKEN='...'
 export DEEPSEEK_API_KEY='...'
 export CILIUM_TARGET_MINOR=1.18
 cilium/tools/run-cilium-upgrade.sh

--- a/.github/workflows/cherry-pick.yaml
+++ b/.github/workflows/cherry-pick.yaml
@@ -24,12 +24,12 @@ jobs:
         id: command
         uses: actions/github-script@v7
         env:
-          HAS_COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN != '' }}
+          HAS_PR_TOKEN: ${{ secrets.PR_TOKEN != '' }}
         with:
           github-token: ${{ github.token }}
           script: |
             const body = context.payload.comment.body.trim();
-            const match = body.match(/^\/cherry-pick\s+(cilium\/v[0-9]+\.[0-9]+)\s*$/);
+            const match = body.match(/^\/cherry-pick\s+(cilium\/release-v[0-9]+\.[0-9]+)\s*$/);
             if (!match) {
               core.info('Comment is not a cherry-pick command; skipping.');
               core.setOutput('run', 'false');
@@ -41,12 +41,12 @@ jobs:
             const actor = context.payload.comment.user.login;
             const targetBranch = match[1];
 
-            if (process.env.HAS_COPILOT_GITHUB_TOKEN !== 'true') {
+            if (process.env.HAS_PR_TOKEN !== 'true') {
               await github.rest.issues.createComment({
                 owner,
                 repo,
                 issue_number: issueNumber,
-                body: 'Cannot run `/cherry-pick`: repository secret `COPILOT_GITHUB_TOKEN` is required to create a PR that triggers validation workflows.'
+                body: 'Cannot run `/cherry-pick`: repository secret `PR_TOKEN` is required to create a PR that triggers validation workflows.'
               });
               core.setOutput('run', 'false');
               return;
@@ -184,7 +184,7 @@ jobs:
       - name: Push cherry-pick branch
         if: steps.command.outputs.run == 'true' && steps.cherry-pick.outputs.has_changes == 'true'
         env:
-          PUSH_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+          PUSH_TOKEN: ${{ secrets.PR_TOKEN }}
           CHERRY_PICK_BRANCH: ${{ steps.cherry-pick.outputs.branch }}
         run: |
           set -euo pipefail
@@ -205,7 +205,7 @@ jobs:
           PR_NUMBER: ${{ steps.command.outputs.pr_number }}
           COMMENT_URL: ${{ github.event.comment.html_url }}
         with:
-          github-token: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+          github-token: ${{ secrets.PR_TOKEN }}
           script: |
             const { owner, repo } = context.repo;
             const branch = process.env.CHERRY_PICK_BRANCH;

--- a/.github/workflows/comment.yaml
+++ b/.github/workflows/comment.yaml
@@ -24,10 +24,10 @@ jobs:
     steps:
       - uses: actions/github-script@v7
         with:
-          # Prefer the dedicated PAT (COPILOT_GITHUB_TOKEN) when available;
+          # Prefer the dedicated PR PAT (PR_TOKEN) when available;
           # otherwise the base-repo GITHUB_TOKEN (writable in workflow_run
           # context) is sufficient. This job never checks out fork code.
-          github-token: ${{ secrets.COPILOT_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.PR_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
             const run = context.payload.workflow_run;
             const { owner, repo } = context.repo;

--- a/.github/workflows/monthly-cilium-upgrade.yaml
+++ b/.github/workflows/monthly-cilium-upgrade.yaml
@@ -32,7 +32,7 @@ jobs:
         id: discover
         env:
           GITHUB_TOKEN: ${{ github.token }}
-          COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+          PR_TOKEN: ${{ secrets.PR_TOKEN }}
         run: |
           set -euo pipefail
 
@@ -120,7 +120,7 @@ jobs:
             if branch_exists "${new_branch}"; then
               source_branch="${new_branch}"
             else
-              branch_push_token="${COPILOT_GITHUB_TOKEN:-${GITHUB_TOKEN}}"
+              branch_push_token="${PR_TOKEN:-${GITHUB_TOKEN}}"
               if [[ -z "${branch_push_token}" ]]; then
                 echo "Missing token; required to create ${new_branch} from ${source_branch}." >&2
                 exit 1
@@ -255,23 +255,23 @@ jobs:
       - name: Verify PR token
         if: steps.upgrade.outputs.changed == 'true'
         env:
-          COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+          PR_TOKEN: ${{ secrets.PR_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
         run: |
           set -euo pipefail
 
-          test -n "${COPILOT_GITHUB_TOKEN}" || {
-            echo "Missing repository secret COPILOT_GITHUB_TOKEN" >&2
+          test -n "${PR_TOKEN}" || {
+            echo "Missing repository secret PR_TOKEN" >&2
             exit 1
           }
 
           curl --fail --silent --show-error --location \
             -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer ${COPILOT_GITHUB_TOKEN}" \
+            -H "Authorization: Bearer ${PR_TOKEN}" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             "https://api.github.com/repos/${GITHUB_REPOSITORY}" \
             >/dev/null || {
-              echo "COPILOT_GITHUB_TOKEN is not valid for ${GITHUB_REPOSITORY}." >&2
+              echo "PR_TOKEN is not valid for ${GITHUB_REPOSITORY}." >&2
               echo "Check that the repository secret is current and grants Contents: Read and write plus Pull requests: Read and write." >&2
               exit 1
             }
@@ -280,19 +280,19 @@ jobs:
         if: steps.upgrade.outputs.changed == 'true'
         working-directory: worktree
         env:
-          COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+          PR_TOKEN: ${{ secrets.PR_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
         run: |
           set -euo pipefail
 
-          git remote set-url origin "https://x-access-token:${COPILOT_GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          git remote set-url origin "https://x-access-token:${PR_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
 
       - name: Create or update upgrade PR
         if: steps.upgrade.outputs.changed == 'true'
         id: cpr
         uses: peter-evans/create-pull-request@v8
         with:
-          token: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+          token: ${{ secrets.PR_TOKEN }}
           path: worktree
           base: ${{ matrix.branch }}
           branch: automation/cilium-v${{ matrix.target_minor }}-latest
@@ -325,7 +325,7 @@ jobs:
       - name: Check out main
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+          token: ${{ secrets.PR_TOKEN }}
           fetch-depth: 0
 
       - name: Update supported Cilium versions file
@@ -359,41 +359,41 @@ jobs:
 
       - name: Verify PR token
         env:
-          COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+          PR_TOKEN: ${{ secrets.PR_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
         run: |
           set -euo pipefail
 
-          test -n "${COPILOT_GITHUB_TOKEN}" || {
-            echo "Missing repository secret COPILOT_GITHUB_TOKEN" >&2
+          test -n "${PR_TOKEN}" || {
+            echo "Missing repository secret PR_TOKEN" >&2
             exit 1
           }
 
           curl --fail --silent --show-error --location \
             -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer ${COPILOT_GITHUB_TOKEN}" \
+            -H "Authorization: Bearer ${PR_TOKEN}" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             "https://api.github.com/repos/${GITHUB_REPOSITORY}" \
             >/dev/null || {
-              echo "COPILOT_GITHUB_TOKEN is not valid for ${GITHUB_REPOSITORY}." >&2
+              echo "PR_TOKEN is not valid for ${GITHUB_REPOSITORY}." >&2
               echo "Check that the repository secret is current and grants Contents: Read and write plus Pull requests: Read and write." >&2
               exit 1
             }
 
       - name: Configure manifest PR branch push credentials
         env:
-          COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+          PR_TOKEN: ${{ secrets.PR_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
         run: |
           set -euo pipefail
 
-          git remote set-url origin "https://x-access-token:${COPILOT_GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          git remote set-url origin "https://x-access-token:${PR_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
 
       - name: Create or update manifest PR
         id: manifest-pr
         uses: peter-evans/create-pull-request@v8
         with:
-          token: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+          token: ${{ secrets.PR_TOKEN }}
           base: main
           branch: automation/cilium-supported-versions
           delete-branch: true

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -58,4 +58,3 @@ jobs:
           kubectl config use-context kind-cluster2 && make debug
       - if: always()
         run: make clean
-


### PR DESCRIPTION
## Summary

- Sync the release-branch automation token model to main.
- Use PR_TOKEN for branch push and PR creation/update paths instead of the Copilot credential.
- Keep Copilot credentials scoped to AI repair/upgrade execution and update docs accordingly.

## Validation

- jq empty .github/cilium-supported-versions.json
- git diff --check