### PR TITLE
sync automation workflow to cilium/release-v1.19

### DIFF
--- a/.github/CILIUM_UPDATER.md
+++ b/.github/CILIUM_UPDATER.md
@@ -88,32 +88,40 @@ minor 为起点复制出来的。Hubble CLI 也按同一个 `X.Y` minor 选择
 
 - Base branch：`cilium/release-vX.Y`
 - Head branch：`automation/cilium-vX.Y-latest`
-- Title：`chore: 将 Cilium X.Y 升级至 X.Y.z`
+- Title：`[AutoUpdate vX.Y] Cilium version vA.B.C -> vX.Y.z`
 
-pull request 验证 workflow 会针对目标为 `cilium/release-v*` 分支的 PR 和 push 运行。
+pull request 验证 workflow 会针对目标为 `cilium/release-v*` 分支的 PR 和 push 运行，
+也可以通过 `workflow_dispatch` 手动指定 `ref` 运行。自动升级 PR 使用仓库默认的
+`GITHUB_TOKEN` 创建，因此 GitHub 可能要求人工在 PR 页面批准或手动触发 e2e。月度
+升级 workflow 会在创建 PR 前先运行同一套 e2e，避免把明显失败的升级直接提交成 PR。
 
-## e2e 失败后的 AI 修复流程
+## PR 前 e2e 和 AI 修复流程
 
-首次升级阶段只负责生成升级 diff、通过静态验证并创建或更新 PR；它不会在同一次
-运行里等待 PR e2e 完成。PR 创建后，`Validate Cilium Installation` workflow 会
-运行 `make test-single` 和 `make test-multi`。如果 e2e 失败，后续修复应作为独立
-阶段处理，避免把初始升级、CI 诊断和推送修复混在同一个不可控的 agent 回合里。
+首次升级阶段会生成升级 diff 并通过静态验证。之后，月度 workflow 会在同一个
+`worktree` 里运行 `make test-single` 和 `make test-multi`，只有 e2e 通过后才创建
+或更新 PR。
 
-推荐流程：
+默认流程：
 
-1. 检出失败 PR 的 head 分支，例如 `automation/cilium-vX.Y-latest`。
-2. 获取失败的 GitHub Actions job 完整日志，并优先定位第一个真实失败点。不要只根据
-   `make debug` 最后的 event 下结论。
-3. 让 AI 使用 `cilium/tools/prompts/cilium-upgrade-e2e-repair.md` 作为修复提示词。
-   该提示词要求 AI 对照 PR diff、目标 chart 默认值、官方升级文档和 CI 日志分析根因。
-4. 如果失败 job 的 kind 集群仍然可用，修复后优先在当前集群上重新执行安装脚本或
-   `cilium/setup.sh`，让 Helm 走 `upgrade --install` 原地更新：
+1. AI 先按 `cilium/tools/prompts/cilium-upgrade.md` 完成版本升级和静态验证。
+2. workflow 在创建 PR 前运行 `make test-single` 和 `make test-multi`。
+3. 如果 e2e 失败且仓库 variable `ENABLE_AI_E2E_REPAIR=true`，workflow 会收集失败日志，
+   让 AI 使用 `cilium/tools/prompts/cilium-upgrade-e2e-repair.md` 作为修复提示词。
+   该提示词要求 AI 对照升级 diff、目标 chart 默认值、官方升级文档和 CI 日志分析根因。
+4. 修复脚本在已有升级 diff 的基础上做最小修改，并要求 AI 在修复总结中明确列出：
+   修改了哪些参数或脚本行为、每项修改的作用、为什么能让 e2e 通过。
+5. 修复后 workflow 重新运行 `make test-single` 和 `make test-multi`。这两个目标的
+   集群创建逻辑是幂等的：如果同名 kind 集群已经存在，就跳过创建，继续执行
+   `install-cilium.sh` / `setup.sh`，让 Helm 走 `upgrade --install` 验证修复后的
+   `values.yaml` 或脚本参数。只有修复后 e2e 通过，才继续创建或更新 PR；否则
+   workflow 失败，不提交 PR。
+6. 最终 PR 描述会追加“升级测试和修复记录”，包括初次 e2e 结果、是否运行 AI 修复、
+   修复说明、最终验证结果。
+
+如果需要人工复现失败，仍可检出自动升级分支并按提示词里的建议优先使用原地升级：
+
    - `test/scripts/install-cilium.sh <cluster> <cluster-id> <pod-cidr> <hubble-port> <clustermesh-port>`
    - 或在 `cilium/` 目录下使用同一组环境变量重新运行 `./setup.sh`
-5. 原地升级后继续运行 `cilium status --wait`、必要的 `kubectl wait` 和失败用例。
-   只有当旧资源残留让问题无法判断时，才清理并重建 kind 集群。
-6. 修复验证通过后，AI 只暂存相关文件，提交并推送到同一个 PR head 分支。推送会再次
-   触发 PR e2e，保留 CI 的最终结果作为合并依据。
 
 这种模式可以显著缩短调试周期：例如 values 字段缺失导致 Pod 挂载失败时，修复
 `cilium/values.yaml` 后直接重新运行 Helm upgrade，即可验证 Deployment 是否重新
@@ -127,17 +135,12 @@ workflow 会按优先级依次尝试每个 AI CLI，直到其中一个成功：
 
 - `COPILOT_GITHUB_TOKEN`：Copilot CLI 凭据，需要可用于 `@github/copilot` CLI。
   它只用于 AI 升级步骤，不用于创建分支或 PR。
-- `PR_TOKEN`：fine-grained PAT，需要具备 `Contents: Read and write` 和
-  `Pull requests: Read and write` 权限。workflow 使用该 token 创建维护分支、推送
-  自动化分支并创建或更新 PR。
 - `DEEPSEEK_API_KEY`：供 `opencode run` 调用 DeepSeek 使用的 API key。
 
-创建缺失的 `cilium/release-vX.Y` 维护分支时，workflow 会优先使用 `PR_TOKEN`，
-未设置时回退到默认 `GITHUB_TOKEN`。创建或更新 PR 时必须设置 `PR_TOKEN`。
-workflow 默认的 `GITHUB_TOKEN` 绝不会用作 Copilot 凭据或 PR 创建 token。使用默认
-token 创建的 pull request 不会触发新的 `pull_request` 事件，因此
-`.github/workflows/pr.yaml` 不会启动 e2e 任务。`PR_TOKEN` 会让 PR 创建
-表现得像普通用户操作，并自动触发这些测试。
+workflow 使用默认 `GITHUB_TOKEN` 创建缺失的 `cilium/release-vX.Y` 维护分支、
+推送自动化分支并创建或更新 PR。这样不依赖个人 PAT 或组织成员权限。代价是 GitHub
+可能不会自动运行 bot 创建 PR 的普通 `pull_request` e2e，需要由 assignee 在 PR 页面
+批准运行，或者手动触发 `Validate Cilium Installation` workflow 并填写 PR head 分支。
 
 可选的仓库 variables：
 
@@ -145,6 +148,10 @@ token 创建的 pull request 不会触发新的 `pull_request` 事件，因此
   DeepSeek 使用 `deepseek/deepseek-v4-pro`。
 - `DEEPSEEK_MODEL`：只覆盖 DeepSeek 的 opencode 模型名称，例如
   `deepseek/deepseek-v4-pro`。
+- `CILIUM_UPGRADE_PR_ASSIGNEE`：自动升级 PR 和版本清单 PR 的 assignee。省略时为
+  `cyclinder`。
+- `ENABLE_AI_E2E_REPAIR`：设置为 `true` 时，允许月度升级 workflow 在 PR 前 e2e
+  失败后运行 AI 修复并重跑 e2e。
 
 初始升级提示词维护在 `cilium/tools/prompts/cilium-upgrade.md`。PR e2e 失败后的
 修复提示词维护在 `cilium/tools/prompts/cilium-upgrade-e2e-repair.md`。workflow 将
@@ -168,7 +175,6 @@ npm install --global @github/copilot@latest
 npm install --global opencode-ai@latest
 
 export COPILOT_GITHUB_TOKEN='...'
-export PR_TOKEN='...'
 export DEEPSEEK_API_KEY='...'
 export CILIUM_TARGET_MINOR=1.18
 cilium/tools/run-cilium-upgrade.sh

--- a/.github/workflows/monthly-cilium-upgrade.yaml
+++ b/.github/workflows/monthly-cilium-upgrade.yaml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  issues: write
   pull-requests: write
 
 concurrency:
@@ -32,7 +33,6 @@ jobs:
         id: discover
         env:
           GITHUB_TOKEN: ${{ github.token }}
-          PR_TOKEN: ${{ secrets.PR_TOKEN }}
         run: |
           set -euo pipefail
 
@@ -120,7 +120,7 @@ jobs:
             if branch_exists "${new_branch}"; then
               source_branch="${new_branch}"
             else
-              branch_push_token="${PR_TOKEN:-${GITHUB_TOKEN}}"
+              branch_push_token="${GITHUB_TOKEN}"
               if [[ -z "${branch_push_token}" ]]; then
                 echo "Missing token; required to create ${new_branch} from ${source_branch}." >&2
                 exit 1
@@ -173,7 +173,7 @@ jobs:
     needs: prepare-branches
     if: needs.prepare-branches.outputs.branches != '[]'
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 180
     strategy:
       fail-fast: false
       matrix:
@@ -252,47 +252,185 @@ jobs:
         run: |
           updater/cilium/tools/run-cilium-upgrade.sh
 
-      - name: Verify PR token
+      - name: Run pre-PR e2e validation
+        if: steps.upgrade.outputs.changed == 'true'
+        id: initial-e2e
+        working-directory: worktree
+        env:
+          DISABLE_HELM_ATOMIC: "true"
+        run: |
+          set +e
+
+          log_file="/tmp/cilium-upgrade-initial-e2e.log"
+          exec > >(tee "${log_file}") 2>&1
+
+          status="success"
+
+          echo "## Initial single-cluster e2e"
+          if ! make test-single; then
+            status="failed"
+            make debug || true
+          fi
+          if [[ "${status}" == "success" ]]; then
+            make clean || true
+          else
+            echo "Keeping single-cluster environment for AI repair."
+          fi
+
+          echo "## Initial multi-cluster e2e"
+          if ! make test-multi; then
+            status="failed"
+            echo "=== Cluster1 Debug ==="
+            kubectl config use-context kind-cluster1 && make debug || true
+            echo "=== Cluster2 Debug ==="
+            kubectl config use-context kind-cluster2 && make debug || true
+          fi
+          if [[ "${status}" == "success" ]]; then
+            make clean || true
+          else
+            echo "Keeping e2e clusters for AI repair."
+          fi
+
+          {
+            echo "status=${status}"
+            echo "log_file=${log_file}"
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Run AI e2e repair
+        if: >
+          steps.upgrade.outputs.changed == 'true' &&
+          steps.initial-e2e.outputs.status == 'failed' &&
+          vars.ENABLE_AI_E2E_REPAIR == 'true'
+        id: repair
+        working-directory: worktree
+        env:
+          AI_MODEL: ${{ vars.AI_MODEL }}
+          DEEPSEEK_MODEL: ${{ vars.DEEPSEEK_MODEL }}
+          COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+          DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
+          CILIUM_E2E_FAILED_LOG: ${{ steps.initial-e2e.outputs.log_file }}
+          CILIUM_E2E_REPAIR_SUMMARY: /tmp/cilium-e2e-repair-summary.md
+          CILIUM_E2E_REPAIR_ALLOW_DIRTY: "true"
+          CILIUM_E2E_PR_NUMBER: "pre-pr"
+          CILIUM_E2E_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          CILIUM_PROJECT_ROOT: ${{ github.workspace }}/worktree
+          CILIUM_UPDATER_ROOT: ${{ github.workspace }}/updater
+        run: ../updater/cilium/tools/run-cilium-e2e-repair.sh
+
+      - name: Rerun e2e after AI repair
+        if: steps.repair.outputs.changed == 'true'
+        id: repaired-e2e
+        working-directory: worktree
+        env:
+          DISABLE_HELM_ATOMIC: "true"
+        run: |
+          set +e
+
+          log_file="/tmp/cilium-upgrade-repaired-e2e.log"
+          exec > >(tee "${log_file}") 2>&1
+
+          status="success"
+
+          echo "## Repaired single-cluster e2e"
+          if ! make test-single; then
+            status="failed"
+            make debug || true
+          fi
+
+          echo "## Repaired multi-cluster e2e"
+          if ! make test-multi; then
+            status="failed"
+            echo "=== Cluster1 Debug ==="
+            kubectl config use-context kind-cluster1 && make debug || true
+            echo "=== Cluster2 Debug ==="
+            kubectl config use-context kind-cluster2 && make debug || true
+          fi
+          if [[ "${status}" == "success" ]]; then
+            make clean || true
+          else
+            echo "Keeping failed repaired e2e clusters for debugging."
+          fi
+
+          {
+            echo "status=${status}"
+            echo "log_file=${log_file}"
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Require e2e success before PR
         if: steps.upgrade.outputs.changed == 'true'
         env:
-          PR_TOKEN: ${{ secrets.PR_TOKEN }}
-          GITHUB_REPOSITORY: ${{ github.repository }}
+          INITIAL_E2E_STATUS: ${{ steps.initial-e2e.outputs.status }}
+          REPAIR_CHANGED: ${{ steps.repair.outputs.changed }}
+          REPAIRED_E2E_STATUS: ${{ steps.repaired-e2e.outputs.status }}
         run: |
           set -euo pipefail
 
-          test -n "${PR_TOKEN}" || {
-            echo "Missing repository secret PR_TOKEN" >&2
-            exit 1
-          }
+          if [[ "${INITIAL_E2E_STATUS}" == "success" ]]; then
+            exit 0
+          fi
 
-          curl --fail --silent --show-error --location \
-            -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer ${PR_TOKEN}" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            "https://api.github.com/repos/${GITHUB_REPOSITORY}" \
-            >/dev/null || {
-              echo "PR_TOKEN is not valid for ${GITHUB_REPOSITORY}." >&2
-              echo "Check that the repository secret is current and grants Contents: Read and write plus Pull requests: Read and write." >&2
-              exit 1
-            }
+          if [[ "${REPAIR_CHANGED}" == "true" && "${REPAIRED_E2E_STATUS}" == "success" ]]; then
+            exit 0
+          fi
 
-      - name: Configure PR branch push credentials
+          echo "Cilium upgrade e2e did not pass; refusing to create an upgrade PR." >&2
+          echo "Initial e2e: ${INITIAL_E2E_STATUS}" >&2
+          echo "Repair changed: ${REPAIR_CHANGED:-false}" >&2
+          echo "Repaired e2e: ${REPAIRED_E2E_STATUS:-not-run}" >&2
+          exit 1
+
+      - name: Append e2e and repair summary to PR body
         if: steps.upgrade.outputs.changed == 'true'
         working-directory: worktree
         env:
-          PR_TOKEN: ${{ secrets.PR_TOKEN }}
-          GITHUB_REPOSITORY: ${{ github.repository }}
+          PR_BODY_PATH: ${{ steps.upgrade.outputs.pr_body_path }}
+          INITIAL_E2E_STATUS: ${{ steps.initial-e2e.outputs.status }}
+          REPAIR_CHANGED: ${{ steps.repair.outputs.changed }}
+          REPAIR_AGENT: ${{ steps.repair.outputs.agent }}
+          REPAIRED_E2E_STATUS: ${{ steps.repaired-e2e.outputs.status }}
+          REPAIR_SUMMARY_PATH: ${{ steps.repair.outputs.summary_path }}
         run: |
           set -euo pipefail
 
-          git remote set-url origin "https://x-access-token:${PR_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          {
+            echo
+            echo "### 升级测试和修复记录"
+            echo
+            echo "| 阶段 | 结果 | 说明 |"
+            echo "|---|---|---|"
+            echo "| 初次 AI 升级后 e2e | ${INITIAL_E2E_STATUS} | 本 workflow 在创建 PR 前运行 \`make test-single\` 和 \`make test-multi\`。 |"
+            if [[ "${REPAIR_CHANGED}" == "true" ]]; then
+              echo "| AI e2e 修复 | success | 使用 ${REPAIR_AGENT} 基于失败日志修复，并通过 \`make prepare\` / \`make ci-validate\`。 |"
+              echo "| 修复后 e2e | ${REPAIRED_E2E_STATUS} | 修复后重新运行 \`make test-single\` 和 \`make test-multi\`；已有同名 kind 集群会被复用，并重新执行 Cilium 安装。 |"
+            else
+              echo "| AI e2e 修复 | not-run | 初次 e2e 已通过，未额外调整参数；或未启用 \`ENABLE_AI_E2E_REPAIR\`。 |"
+            fi
+            echo
+            if [[ "${REPAIR_CHANGED}" == "true" && -n "${REPAIR_SUMMARY_PATH}" && -s "${REPAIR_SUMMARY_PATH}" ]]; then
+              echo "#### AI 修复说明"
+              echo
+              cat "${REPAIR_SUMMARY_PATH}"
+              echo
+            else
+              echo "#### 额外参数调整"
+              echo
+              echo "无。初次升级生成的配置通过 e2e，未在测试阶段追加手动参数修复。"
+              echo
+            fi
+            echo "#### 最终验证"
+            echo
+            echo "- \`make prepare\`：通过"
+            echo "- \`make ci-validate\`：通过"
+            echo "- \`make test-single\`：通过"
+            echo "- \`make test-multi\`：通过"
+          } >> "${PR_BODY_PATH}"
 
       - name: Create or update upgrade PR
         if: steps.upgrade.outputs.changed == 'true'
         id: cpr
         uses: peter-evans/create-pull-request@v8
         with:
-          token: ${{ secrets.PR_TOKEN }}
+          token: ${{ github.token }}
           path: worktree
           base: ${{ matrix.branch }}
           branch: automation/cilium-v${{ matrix.target_minor }}-latest
@@ -301,6 +439,7 @@ jobs:
             [AutoUpdate v${{ matrix.target_minor }}] Cilium version v${{ steps.upgrade.outputs.current_version }} -> v${{ steps.upgrade.outputs.latest_version }}
           title: '[AutoUpdate v${{ matrix.target_minor }}] Cilium version v${{ steps.upgrade.outputs.current_version }} -> v${{ steps.upgrade.outputs.latest_version }}'
           body-path: ${{ steps.upgrade.outputs.pr_body_path }}
+          assignees: ${{ vars.CILIUM_UPGRADE_PR_ASSIGNEE || 'cyclinder' }}
           add-paths: |
             cilium/**
             test/**
@@ -325,7 +464,7 @@ jobs:
       - name: Check out main
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.PR_TOKEN }}
+          token: ${{ github.token }}
           fetch-depth: 0
 
       - name: Update supported Cilium versions file
@@ -357,48 +496,17 @@ jobs:
             ' "${manifest_path}" > "${tmp_file}"
           mv "${tmp_file}" "${manifest_path}"
 
-      - name: Verify PR token
-        env:
-          PR_TOKEN: ${{ secrets.PR_TOKEN }}
-          GITHUB_REPOSITORY: ${{ github.repository }}
-        run: |
-          set -euo pipefail
-
-          test -n "${PR_TOKEN}" || {
-            echo "Missing repository secret PR_TOKEN" >&2
-            exit 1
-          }
-
-          curl --fail --silent --show-error --location \
-            -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer ${PR_TOKEN}" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            "https://api.github.com/repos/${GITHUB_REPOSITORY}" \
-            >/dev/null || {
-              echo "PR_TOKEN is not valid for ${GITHUB_REPOSITORY}." >&2
-              echo "Check that the repository secret is current and grants Contents: Read and write plus Pull requests: Read and write." >&2
-              exit 1
-            }
-
-      - name: Configure manifest PR branch push credentials
-        env:
-          PR_TOKEN: ${{ secrets.PR_TOKEN }}
-          GITHUB_REPOSITORY: ${{ github.repository }}
-        run: |
-          set -euo pipefail
-
-          git remote set-url origin "https://x-access-token:${PR_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
-
       - name: Create or update manifest PR
         id: manifest-pr
         uses: peter-evans/create-pull-request@v8
         with:
-          token: ${{ secrets.PR_TOKEN }}
+          token: ${{ github.token }}
           base: main
           branch: automation/cilium-supported-versions
           delete-branch: true
           commit-message: 'chore: 更新 Cilium 支持版本清单'
           title: 'chore: 更新 Cilium 支持版本清单'
+          assignees: ${{ vars.CILIUM_UPGRADE_PR_ASSIGNEE || 'cyclinder' }}
           body: |
             更新 `.github/cilium-supported-versions.json` 中记录的 Cilium 最新 patch 版本。
           add-paths: |

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,6 +1,11 @@
 name: Validate Cilium Installation
 
 on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Branch, tag, or SHA to validate'
+        required: false
   pull_request:
     branches:
       - 'cilium/release-v*'
@@ -13,12 +18,17 @@ on:
     branches:
       - 'cilium/release-v*'
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     name: Validate Configuration
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
       - run: make install-tools
       - run: make prepare
       - run: make ci-validate
@@ -32,6 +42,8 @@ jobs:
       DISABLE_HELM_ATOMIC: "true"
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
       - run: make install-tools
       - run: make test-single
       - if: failure()
@@ -48,6 +60,8 @@ jobs:
       DISABLE_HELM_ATOMIC: "true"
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
       - run: make install-tools
       - run: make test-multi
       - if: failure()

--- a/cilium/tools/run-cilium-e2e-repair.sh
+++ b/cilium/tools/run-cilium-e2e-repair.sh
@@ -1,0 +1,310 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_project_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+project_root=$(cd "${CILIUM_PROJECT_ROOT:-${script_project_root}}" && pwd)
+updater_root=$(cd "${CILIUM_UPDATER_ROOT:-${script_project_root}}" && pwd)
+prompt_file="${updater_root}/cilium/tools/prompts/cilium-upgrade-e2e-repair.md"
+failed_log_file="${CILIUM_E2E_FAILED_LOG:-/tmp/cilium-e2e-failed.log}"
+repair_summary_file="${CILIUM_E2E_REPAIR_SUMMARY:-/tmp/cilium-e2e-repair-summary.md}"
+ai_output=$(mktemp)
+
+cleanup() {
+    rm -f "${ai_output}" "${baseline_diff:-}" "${current_diff:-}" \
+        "${baseline_status:-}" "${current_status:-}"
+}
+trap cleanup EXIT
+
+usage() {
+    cat <<'EOF'
+Usage: cilium/tools/run-cilium-e2e-repair.sh
+
+Runs an AI-assisted repair pass for a failed Cilium upgrade e2e workflow.
+This script only modifies the current worktree. The caller is responsible for
+reviewing, committing, and pushing any changes.
+
+Environment:
+  CILIUM_E2E_FAILED_LOG       Failed GitHub Actions log path. Defaults to
+                              /tmp/cilium-e2e-failed.log.
+  CILIUM_E2E_REPAIR_SUMMARY   Output summary path. Defaults to
+                              /tmp/cilium-e2e-repair-summary.md.
+  CILIUM_E2E_PR_NUMBER        Pull request number for context.
+  CILIUM_E2E_RUN_URL          Failed workflow run URL for context.
+  COPILOT_GITHUB_TOKEN        Copilot CLI credential.
+  COPILOT_MODEL               Optional model name passed to copilot.
+  DEEPSEEK_API_KEY            DeepSeek API key used by `opencode run`.
+  DEEPSEEK_MODEL              Optional opencode model name.
+  AI_MODEL                    Optional fallback model name.
+  AI_AGENT_TIMEOUT            Maximum runtime for each AI CLI attempt.
+                              Defaults to 20m.
+  AI_AGENT_MAX_ATTEMPTS       Maximum attempts per AI CLI. Defaults to 2.
+  CILIUM_E2E_REPAIR_ALLOW_DIRTY
+                              Set to "true" when the worktree already contains
+                              the initial AI upgrade diff.
+  CILIUM_PROJECT_ROOT         Repository worktree to modify.
+  CILIUM_UPDATER_ROOT         Repository containing prompts.
+EOF
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+    usage
+    exit 0
+fi
+
+for command in git sed timeout; do
+    if ! command -v "${command}" >/dev/null 2>&1; then
+        echo "Missing required command: ${command}" >&2
+        exit 1
+    fi
+done
+
+cd "${project_root}"
+
+if [[ ! -f "${prompt_file}" ]]; then
+    echo "Missing repair prompt: ${prompt_file}" >&2
+    exit 1
+fi
+
+if [[ ! -s "${failed_log_file}" ]]; then
+    echo "Missing failed e2e log: ${failed_log_file}" >&2
+    exit 1
+fi
+
+allow_dirty=${CILIUM_E2E_REPAIR_ALLOW_DIRTY:-false}
+baseline_diff=$(mktemp)
+current_diff=$(mktemp)
+baseline_status=$(mktemp)
+current_status=$(mktemp)
+
+if [[ "${allow_dirty}" != "true" ]] && [[ -n "$(git status --porcelain)" ]]; then
+    echo "The repair worktree must be clean before AI changes are applied." >&2
+    git status --short >&2
+    exit 1
+fi
+
+git diff --binary > "${baseline_diff}"
+git status --short > "${baseline_status}"
+
+agent_order=(copilot deepseek)
+agent_timeout=${AI_AGENT_TIMEOUT:-20m}
+agent_max_attempts=${AI_AGENT_MAX_ATTEMPTS:-2}
+success_agent=""
+
+if ! [[ "${agent_max_attempts}" =~ ^[0-9]+$ ]] || [[ "${agent_max_attempts}" -lt 1 ]]; then
+    echo "AI_AGENT_MAX_ATTEMPTS must be a positive integer; got '${AI_AGENT_MAX_ATTEMPTS}'." >&2
+    exit 1
+fi
+
+credential_for() {
+    case "$1" in
+        copilot) printf '%s' "${COPILOT_GITHUB_TOKEN:-}" ;;
+        deepseek) printf '%s' "${DEEPSEEK_API_KEY:-}" ;;
+    esac
+}
+
+model_for() {
+    case "$1" in
+        copilot)  printf '%s' "${COPILOT_MODEL:-${AI_MODEL:-}}" ;;
+        deepseek) printf '%s' "${DEEPSEEK_MODEL:-${AI_MODEL:-deepseek/deepseek-v4-flash}}" ;;
+    esac
+}
+
+credential_usable_for() {
+    local agent="$1"
+    local credential
+    credential=$(credential_for "${agent}")
+
+    case "${agent}" in
+        copilot)
+            if [[ "${credential}" == ghp_* ]]; then
+                echo "Skipping ${agent}: COPILOT_GITHUB_TOKEN is a classic PAT (ghp_), which Copilot CLI does not support." >&2
+                return 1
+            fi
+            ;;
+    esac
+    return 0
+}
+
+reset_worktree() {
+    if [[ "${allow_dirty}" == "true" ]]; then
+        echo "Keeping dirty baseline worktree; not resetting initial upgrade files." >&2
+    else
+        git checkout -- cilium test README.md Makefile Makefile.defs 2>/dev/null || true
+        git clean -fd -- cilium test README.md Makefile Makefile.defs 2>/dev/null || true
+    fi
+    rm -f "${repair_summary_file}"
+}
+
+print_ai_output() {
+    local agent="$1"
+
+    if [[ ! -s "${ai_output}" ]]; then
+        echo "${agent} produced no CLI stderr output." >&2
+        return 0
+    fi
+
+    echo "::group::${agent} CLI output" >&2
+    sed -n '1,240p' "${ai_output}" >&2
+    if [[ "$(wc -l < "${ai_output}")" -gt 240 ]]; then
+        echo "... output truncated; showing first 240 lines" >&2
+    fi
+    echo "::endgroup::" >&2
+}
+
+allowed_changes_only() {
+    local invalid_paths
+    invalid_paths=$(
+        git status --short |
+            sed 's/^...//' |
+            grep -Ev '^(cilium/|test/|README\.md$|Makefile$|Makefile\.defs$)' || true
+    )
+    if [[ -n "${invalid_paths}" ]]; then
+        echo "AI repair changed paths outside the allowed scope:" >&2
+        echo "${invalid_paths}" >&2
+        return 1
+    fi
+}
+
+has_new_repair_changes() {
+    git diff --binary > "${current_diff}"
+    git status --short > "${current_status}"
+    ! cmp -s "${baseline_diff}" "${current_diff}" ||
+        ! cmp -s "${baseline_status}" "${current_status}"
+}
+
+run_static_validation() {
+    make prepare
+    make ci-validate
+}
+
+run_single_agent() {
+    local agent="$1"
+    local credential
+    local model
+    local -a model_args=()
+    local branch
+    local run_url
+    local pr_number
+    local prompt
+
+    credential=$(credential_for "${agent}")
+    [[ -n "${credential}" ]] || return 1
+
+    model=$(model_for "${agent}")
+    [[ -z "${model}" ]] || model_args=(--model "${model}")
+
+    branch=$(git branch --show-current)
+    run_url=${CILIUM_E2E_RUN_URL:-unknown}
+    pr_number=${CILIUM_E2E_PR_NUMBER:-unknown}
+    prompt="Read and follow ${prompt_file}. The failed e2e log is ${failed_log_file}. PR number: ${pr_number}. Workflow run: ${run_url}. Current branch: ${branch}. Analyze the failed log, make the smallest safe repair in this working tree, run relevant validation if possible, and write a Chinese repair summary to ${repair_summary_file}. The summary must explicitly list every manually changed parameter or script behavior, explain what each change does, and explain why it allowed e2e to pass. If no extra parameter was changed, say so explicitly. Do not commit or push; the workflow will do that after validation."
+
+    case "${agent}" in
+        copilot)
+            COPILOT_GITHUB_TOKEN="${credential}" \
+            timeout --foreground "${agent_timeout}" \
+            copilot \
+                --prompt "${prompt}" \
+                --allow-all \
+                --no-ask-user \
+                --no-auto-update \
+                --silent \
+                --output-format text \
+                "${model_args[@]}" \
+                > "${repair_summary_file}" 2> "${ai_output}"
+            ;;
+        deepseek)
+            DEEPSEEK_API_KEY="${credential}" \
+            timeout --foreground "${agent_timeout}" \
+            opencode run \
+                --dir "${project_root}" \
+                --dangerously-skip-permissions \
+                --variant high \
+                "${model_args[@]}" \
+                "${prompt}" \
+                > "${repair_summary_file}" 2> "${ai_output}"
+            ;;
+    esac
+}
+
+for agent in "${agent_order[@]}"; do
+    if [[ -z "$(credential_for "${agent}")" ]]; then
+        echo "Skipping ${agent}: no credential configured."
+        continue
+    fi
+    if ! credential_usable_for "${agent}"; then
+        continue
+    fi
+    case "${agent}" in
+        copilot)
+            if ! command -v copilot >/dev/null 2>&1; then
+                echo "Skipping ${agent}: CLI not installed."
+                continue
+            fi
+            ;;
+        deepseek)
+            if ! command -v opencode >/dev/null 2>&1; then
+                echo "Skipping ${agent}: opencode CLI not installed."
+                continue
+            fi
+            ;;
+    esac
+
+    echo "Attempting Cilium e2e repair with ${agent} (up to ${agent_max_attempts} attempt(s))..."
+    for attempt in $(seq 1 "${agent_max_attempts}"); do
+        echo "--- ${agent} repair attempt ${attempt}/${agent_max_attempts} ---"
+        agent_status=0
+        if run_single_agent "${agent}"; then
+            agent_status=0
+        else
+            agent_status=$?
+        fi
+
+        if allowed_changes_only && has_new_repair_changes; then
+            if run_static_validation; then
+                success_agent="${agent}"
+                if [[ "${agent_status}" -ne 0 ]]; then
+                    echo "${agent} returned exit status ${agent_status}, but produced a valid repair; accepting result." >&2
+                fi
+                break 2
+            fi
+        else
+            echo "${agent} did not produce repair changes." >&2
+        fi
+
+        print_ai_output "${agent}"
+        if [[ "${attempt}" -lt "${agent_max_attempts}" ]]; then
+            reset_worktree
+        fi
+    done
+    if [[ -z "${success_agent}" ]]; then
+        reset_worktree
+    fi
+done
+
+if [[ -z "${success_agent}" ]]; then
+    echo "All AI repair agents failed, were unavailable, or produced no valid repair." >&2
+    if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+        echo "changed=false" >> "${GITHUB_OUTPUT}"
+    fi
+    exit 1
+fi
+
+if [[ ! -s "${repair_summary_file}" ]]; then
+    cat > "${repair_summary_file}" <<EOF
+### 修复
+
+${success_agent} 生成了 e2e 修复变更，并通过了 \`make prepare\` 和 \`make ci-validate\`。
+EOF
+fi
+
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+    {
+        echo "changed=true"
+        echo "agent=${success_agent}"
+        echo "summary_path=${repair_summary_file}"
+    } >> "${GITHUB_OUTPUT}"
+fi
+
+echo "Cilium e2e repair changes are ready."
+git status --short

--- a/test/Makefile
+++ b/test/Makefile
@@ -80,10 +80,14 @@ test-syntax: ## Test shell scripts syntax
 # Create a cluster with given parameters
 define create-cluster
 	@printf '%b\n' "$(BLUE)Creating cluster: $(1)...$(NC)"
-	@chmod +x $(TEST_DIR)/scripts/create-kind-cluster.sh
-	@export K8S_VERSION=$(K8S_VERSION) ; \
-	$(TEST_DIR)/scripts/create-kind-cluster.sh $(1) $(2) $(3)
-	@printf '%b\n' "$(GREEN)✓ Cluster $(1) created$(NC)"
+	@if kind get clusters 2>/dev/null | grep -Fxq "$(1)"; then \
+		printf '%b\n' "$(YELLOW)Cluster $(1) already exists; reusing it$(NC)"; \
+	else \
+		chmod +x $(TEST_DIR)/scripts/create-kind-cluster.sh; \
+		export K8S_VERSION=$(K8S_VERSION); \
+		$(TEST_DIR)/scripts/create-kind-cluster.sh $(1) $(2) $(3); \
+		printf '%b\n' "$(GREEN)✓ Cluster $(1) created$(NC)"; \
+	fi
 endef
 
 # Install Cilium on a cluster


### PR DESCRIPTION
同步月度 Cilium 升级自动化到 `cilium/release-v1.19`：\n\n- 使用仓库 `GITHUB_TOKEN` 创建/更新自动化 PR，避免依赖个人 PAT。\n- 在创建升级 PR 前运行 e2e；失败时可通过 `ENABLE_AI_E2E_REPAIR=true` 启用 AI 修复并重跑。\n- `make test-single` / `make test-multi` 遇到同名 kind 集群会复用，并继续执行 `install-cilium.sh` / `setup.sh`，用于验证修改后的 values 或参数。\n- PR 描述会追加升级测试和修复记录。\n\n验证：\n- YAML parse 通过\n- `bash -n cilium/tools/run-cilium-e2e-repair.sh` 通过\n- `make test-syntax` 通过